### PR TITLE
JALV as internal JACK client

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ jalv (1.6.1) unstable;
   * Fix compilation with recent Gtkmm versions that require C++11
   * Add jalv -i option to ignore stdin for background use
   * Add several commands to console interface
+  * Add support for running as an internal Jack client (thanks Timo Wischer)
   * Make Suil dependency optional
   * Remove support for deprecated event and uri-map extensions
   * Fix Jack deactivation
@@ -11,7 +12,7 @@ jalv (1.6.1) unstable;
   * Add support for underscore in port names on command line
     (thanks Jośe Fernando Moyano)
 
- -- David Robillard <d@drobilla.net>  Sun, 23 Sep 2018 15:49:05 +0200
+ -- David Robillard <d@drobilla.net>  Sat, 29 Sep 2018 14:16:07 +0200
 
 jalv (1.6.0) stable;
 

--- a/src/jack.c
+++ b/src/jack.c
@@ -51,7 +51,7 @@ jack_shutdown_cb(void* data)
 {
 	Jalv* const jalv = (Jalv*)data;
 	jalv_close_ui(jalv);
-	zix_sem_post(jalv->done);
+	zix_sem_post(&jalv->done);
 }
 
 /** Jack process callback. */

--- a/src/jack.c
+++ b/src/jack.c
@@ -313,8 +313,8 @@ jack_session_cb(jack_session_event_t* event, void* arg)
 }
 #endif /* JALV_JACK_SESSION */
 
-JalvBackend*
-jalv_backend_init(Jalv* jalv)
+static jack_client_t*
+jack_create_client(Jalv* jalv)
 {
 	jack_client_t* client = NULL;
 
@@ -355,6 +355,16 @@ jalv_backend_init(Jalv* jalv)
 	}
 
 	free(jack_name);
+
+	return client;
+}
+
+JalvBackend*
+jalv_backend_init(Jalv* jalv)
+{
+	jack_client_t* const client =
+		jalv->backend ? jalv->backend->client : jack_create_client(jalv);
+
 	if (!client) {
 		return NULL;
 	}

--- a/src/jalv.c
+++ b/src/jalv.c
@@ -1005,7 +1005,7 @@ jalv_open(Jalv* const jalv, int argc, char** argv)
 	if (!(jalv->backend = jalv_backend_init(jalv))) {
 		fprintf(stderr, "Failed to connect to audio system\n");
 		jalv_close(jalv);
-		return -7;
+		return -6;
 	}
 
 	printf("Sample rate:  %u Hz\n", jalv->sample_rate);
@@ -1097,7 +1097,7 @@ jalv_open(Jalv* const jalv, int argc, char** argv)
 		if (!feature_is_supported(jalv, uri)) {
 			fprintf(stderr, "Feature %s is not supported\n", uri);
 			jalv_close(jalv);
-			return -6;
+			return -8;
 		}
 	}
 	lilv_nodes_free(req_feats);
@@ -1108,7 +1108,7 @@ jalv_open(Jalv* const jalv, int argc, char** argv)
 	if (!jalv->instance) {
 		fprintf(stderr, "Failed to instantiate plugin.\n");
 		jalv_close(jalv);
-		return -8;
+		return -9;
 	}
 
 	jalv->features.ext_data.data_access =

--- a/src/jalv_console.c
+++ b/src/jalv_console.c
@@ -245,7 +245,7 @@ jalv_run_custom_ui(Jalv* jalv)
 		show_iface->show(suil_instance_get_handle(jalv->ui_instance));
 
 		// Drive idle interface until interrupted
-		while (!zix_sem_try_wait(jalv->done)) {
+		while (!zix_sem_try_wait(&jalv->done)) {
 			jalv_update(jalv);
 			if (idle_iface->idle(suil_instance_get_handle(jalv->ui_instance))) {
 				break;
@@ -266,7 +266,7 @@ jalv_open_ui(Jalv* jalv)
 {
 	if (!jalv_run_custom_ui(jalv) && !jalv->opts.non_interactive) {
 		// Primitive command prompt for setting control values
-		while (!zix_sem_try_wait(jalv->done)) {
+		while (!zix_sem_try_wait(&jalv->done)) {
 			char line[128];
 			printf("> ");
 			if (fgets(line, sizeof(line), stdin)) {
@@ -276,11 +276,11 @@ jalv_open_ui(Jalv* jalv)
 			}
 		}
 	} else {
-		zix_sem_wait(jalv->done);
+		zix_sem_wait(&jalv->done);
 	}
 
 	// Caller waits on the done sem, so increment it again to exit
-	zix_sem_post(jalv->done);
+	zix_sem_post(&jalv->done);
 
 	return 0;
 }
@@ -288,6 +288,6 @@ jalv_open_ui(Jalv* jalv)
 int
 jalv_close_ui(Jalv* jalv)
 {
-	zix_sem_post(jalv->done);
+	zix_sem_post(&jalv->done);
 	return 0;
 }

--- a/src/jalv_console.c
+++ b/src/jalv_console.c
@@ -69,9 +69,6 @@ jalv_ui_port_event(ZIX_UNUSED Jalv*       jalv,
 int
 jalv_init(int* argc, char*** argv, JalvOptions* opts)
 {
-	opts->controls    = (char**)malloc(sizeof(char*));
-	opts->controls[0] = NULL;
-
 	int n_controls = 0;
 	int a          = 1;
 	for (; a < *argc && (*argv)[a][0] == '-'; ++a) {

--- a/src/jalv_gtk.c
+++ b/src/jalv_gtk.c
@@ -1227,7 +1227,7 @@ jalv_open_ui(Jalv* jalv)
 	gtk_main();
 	suil_instance_free(jalv->ui_instance);
 	jalv->ui_instance = NULL;
-	zix_sem_post(jalv->done);
+	zix_sem_post(&jalv->done);
 	return 0;
 }
 

--- a/src/jalv_gtkmm2.cpp
+++ b/src/jalv_gtkmm2.cpp
@@ -97,7 +97,7 @@ jalv_open_ui(Jalv* jalv)
 
 	delete window;
 	delete jalv_gtk_main;
-	zix_sem_post(jalv->done);
+	zix_sem_post(&jalv->done);
 
 	return 0;
 }

--- a/src/jalv_internal.h
+++ b/src/jalv_internal.h
@@ -32,12 +32,14 @@
 
 #include "lv2/lv2plug.in/ns/ext/atom/atom.h"
 #include "lv2/lv2plug.in/ns/ext/atom/forge.h"
+#include "lv2/lv2plug.in/ns/ext/data-access/data-access.h"
 #include "lv2/lv2plug.in/ns/ext/log/log.h"
 #include "lv2/lv2plug.in/ns/ext/midi/midi.h"
 #include "lv2/lv2plug.in/ns/ext/resize-port/resize-port.h"
 #include "lv2/lv2plug.in/ns/ext/state/state.h"
 #include "lv2/lv2plug.in/ns/ext/urid/urid.h"
 #include "lv2/lv2plug.in/ns/ext/worker/worker.h"
+#include "lv2/lv2plug.in/ns/ext/options/options.h"
 
 #include "zix/ring.h"
 #include "zix/sem.h"
@@ -263,6 +265,23 @@ typedef struct {
 	bool                        threaded;   ///< Run work in another thread
 } JalvWorker;
 
+typedef struct {
+	LV2_Feature                map_feature;
+	LV2_Feature                unmap_feature;
+	LV2_State_Make_Path        make_path;
+	LV2_Feature                make_path_feature;
+	LV2_Worker_Schedule        sched;
+	LV2_Feature                sched_feature;
+	LV2_Worker_Schedule        ssched;
+	LV2_Feature                state_sched_feature;
+	LV2_Log_Log                llog;
+	LV2_Feature                log_feature;
+	LV2_Options_Option         options[6];
+	LV2_Feature                options_feature;
+	LV2_Feature                safe_restore_feature;
+	LV2_Extension_Data_Feature ext_data;
+} JalvFeatures;
+
 struct Jalv {
 	JalvOptions        opts;           ///< Command-line options
 	JalvURIDs          urids;          ///< URIDs
@@ -318,6 +337,8 @@ struct Jalv {
 	bool               has_ui;         ///< True iff a control UI is present
 	bool               request_update; ///< True iff a plugin update is needed
 	bool               safe_restore;   ///< Plugin restore() is thread-safe
+	JalvFeatures       features;
+	const LV2_Feature** feature_list;
 };
 
 int

--- a/src/jalv_internal.h
+++ b/src/jalv_internal.h
@@ -321,7 +321,13 @@ struct Jalv {
 };
 
 int
+jalv_open(Jalv* jalv, int argc, char** argv);
+
+int
 jalv_init(int* argc, char*** argv, JalvOptions* opts);
+
+int
+jalv_close(Jalv* jalv);
 
 JalvBackend*
 jalv_backend_init(Jalv* jalv);

--- a/src/jalv_internal.h
+++ b/src/jalv_internal.h
@@ -284,7 +284,7 @@ struct Jalv {
 	JalvWorker         worker;         ///< Worker thread implementation
 	JalvWorker         state_worker;   ///< Synchronous worker for state restore
 	ZixSem             work_lock;      ///< Lock for plugin work() method
-	ZixSem*            done;           ///< Exit semaphore
+	ZixSem             done;           ///< Exit semaphore
 	ZixSem             paused;         ///< Paused signal from process thread
 	JalvPlayState      play_state;     ///< Current play state
 	char*              temp_dir;       ///< Temporary plugin state directory

--- a/src/jalv_qt.cpp
+++ b/src/jalv_qt.cpp
@@ -725,7 +725,7 @@ jalv_open_ui(Jalv* jalv)
 	timer->start(1000 / jalv->ui_update_hz);
 
 	int ret = app->exec();
-	zix_sem_post(jalv->done);
+	zix_sem_post(&jalv->done);
 	return ret;
 }
 

--- a/src/state.c
+++ b/src/state.c
@@ -36,26 +36,6 @@
 #define NS_RDFS "http://www.w3.org/2000/01/rdf-schema#"
 #define NS_XSD  "http://www.w3.org/2001/XMLSchema#"
 
-extern LV2_Feature map_feature;
-extern LV2_Feature unmap_feature;
-extern LV2_Feature make_path_feature;
-extern LV2_Feature sched_feature;
-extern LV2_Feature state_sched_feature;
-extern LV2_Feature safe_restore_feature;
-extern LV2_Feature log_feature;
-extern LV2_Feature options_feature;
-extern LV2_Feature def_state_feature;
-
-const LV2_Feature* state_features[9] = {
-	&map_feature, &unmap_feature,
-	&make_path_feature,
-	&state_sched_feature,
-	&safe_restore_feature,
-	&log_feature,
-	&options_feature,
-	NULL
-};
-
 char*
 jalv_make_path(LV2_State_Make_Path_Handle handle,
                const char*                path)
@@ -203,6 +183,17 @@ jalv_apply_state(Jalv* jalv, LilvState* state)
 			jalv->play_state = JALV_PAUSE_REQUESTED;
 			zix_sem_wait(&jalv->paused);
 		}
+
+		const LV2_Feature* state_features[9] = {
+			&jalv->features.map_feature,
+			&jalv->features.unmap_feature,
+			&jalv->features.make_path_feature,
+			&jalv->features.state_sched_feature,
+			&jalv->features.safe_restore_feature,
+			&jalv->features.log_feature,
+			&jalv->features.options_feature,
+			NULL
+		};
 
 		lilv_state_restore(
 			state, jalv->instance, set_port_value, jalv, 0, state_features);

--- a/src/symap.c
+++ b/src/symap.c
@@ -68,6 +68,10 @@ symap_new(void)
 void
 symap_free(Symap* map)
 {
+	if (!map) {
+		return;
+	}
+
 	for (uint32_t i = 0; i < map->size; ++i) {
 		free(map->symbols[i]);
 	}

--- a/wscript
+++ b/wscript
@@ -166,6 +166,16 @@ def build(bld):
 
     if bld.env.HAVE_JACK:
         source += 'src/jack.c'
+
+        # Non-GUI internal JACK client library
+        obj = bld(features     = 'c cshlib',
+                  source       = source + ' src/jalv_console.c',
+                  target       = 'jalv',
+                  includes     = ['.', 'src'],
+                  lib          = ['pthread'],
+                  install_path = '${LIBDIR}/jack')
+        autowaf.use_lib(bld, obj, libs)
+        obj.env.cshlib_PATTERN = '%s.so'
     elif bld.env.HAVE_PORTAUDIO:
         source += 'src/portaudio.c'
 


### PR DESCRIPTION
With this patch JALV can be executed in the context of the JACK process to increase the performance.
We will also upstream a patch for JACK2 to execute all internal clients in the same thread to reduce the synchronization overhead.