### PR TITLE
Some minor cleanups

### DIFF
--- a/src/control.c
+++ b/src/control.c
@@ -43,9 +43,6 @@ new_port_control(Jalv* jalv, uint32_t index)
 	id->label          = lilv_port_get_name(plug, lport);
 	id->index          = index;
 	id->group          = lilv_port_get(plug, lport, jalv->nodes.pg_group);
-	id->min            = lilv_port_get(plug, lport, nodes->lv2_minimum);
-	id->max            = lilv_port_get(plug, lport, nodes->lv2_maximum);
-	id->def            = lilv_port_get(plug, lport, nodes->lv2_default);
 	id->value_type     = jalv->forge.Float;
 	id->is_writable    = lilv_port_is_a(plug, lport, nodes->lv2_InputPort);
 	id->is_readable    = lilv_port_is_a(plug, lport, nodes->lv2_OutputPort);

--- a/src/jalv_internal.h
+++ b/src/jalv_internal.h
@@ -117,7 +117,6 @@ typedef struct {
 	size_t      n_points;        ///< Number of scale points
 	ScalePoint* points;          ///< Scale points
 	LV2_URID    value_type;      ///< Type of control value
-	LV2_Atom    value;           ///< Current value
 	LilvNode*   min;             ///< Minimum value
 	LilvNode*   max;             ///< Maximum value
 	LilvNode*   def;             ///< Default value


### PR DESCRIPTION
1.
min, max, def will already be detected with lilv_port_get_range(). Therefore avoid additional calls to lilv_port_get().

2. 
LV2_Atom    value will never used. Therefore remove it