### PR TITLE
Use sigaction() instead of signal()

### DIFF
--- a/src/jalv.c
+++ b/src/jalv.c
@@ -770,6 +770,14 @@ int
 main(int argc, char** argv)
 {
 	Jalv jalv;
+
+#ifndef _WIN32
+	struct sigaction action;
+	sigemptyset (&action.sa_mask);
+	action.sa_flags = 0;
+	action.sa_handler = signal_handler;
+#endif
+
 	memset(&jalv, '\0', sizeof(Jalv));
 	jalv.prog_name     = argv[0];
 	jalv.block_length  = 4096;  /* Should be set by backend */
@@ -879,8 +887,14 @@ main(int argc, char** argv)
 	zix_sem_init(&jalv.paused, 0);
 	zix_sem_init(&jalv.worker.sem, 0);
 
+#ifdef _WIN32
+	/* TODO: Signal() is not working in combination with fgets() */
 	signal(SIGINT, signal_handler);
 	signal(SIGTERM, signal_handler);
+#else
+	sigaction(SIGINT, &action, NULL);
+	sigaction(SIGTERM, &action, NULL);
+#endif
 
 	/* Find all installed plugins */
 	LilvWorld* world = lilv_world_new();


### PR DESCRIPTION
Issue is that even after we do ctrl+c, fgets is waiting for a newline.

Ref : man of signal(7)
If a signal handler is invoked while a system call or library function call is blocked, then either:
1. the call is automatically restarted after the signal handler returns
2. the call fails with the error EINTR.
Which of these two behaviors occurs depends on the interface and whether or not the signal handler was established using the SA_RESTART flag (see sigaction(2)).

We have to use either the siginterrupt() function together with signal(), or use sigaction() instead of signal() for registering the signal handler,
in order to disable restarting a read() system call after a signal.