### PR TITLE
Fix compiler warnings with additional gcc flags

### DIFF
--- a/src/jalv.c
+++ b/src/jalv.c
@@ -384,7 +384,7 @@ jalv_set_control(const ControlID* control,
 	Jalv* jalv = control->jalv;
 	if (control->type == PORT && type == jalv->forge.Float) {
 		struct Port* port = &control->jalv->ports[control->index];
-		port->control = *(float*)body;
+		port->control = *(const float*)body;
 	} else if (control->type == PROPERTY) {
 		// Copy forge since it is used by process thread
 		LV2_Atom_Forge       forge = jalv->forge;

--- a/src/jalv.c
+++ b/src/jalv.c
@@ -723,7 +723,7 @@ jalv_apply_control_arg(Jalv* jalv, const char* s)
 }
 
 static void
-signal_handler(int ignored)
+signal_handler(ZIX_UNUSED int sig)
 {
 	zix_sem_post(&exit_sem);
 }
@@ -975,7 +975,7 @@ main(int argc, char** argv)
 	}
 
 	/* Get a plugin UI */
-	const char* native_ui_type_uri = jalv_native_ui_type(&jalv);
+	const char* native_ui_type_uri = jalv_native_ui_type();
 	jalv.uis = lilv_plugin_get_uis(jalv.plugin);
 	if (!jalv.opts.generic_ui && native_ui_type_uri) {
 #ifdef HAVE_SUIL

--- a/src/jalv_console.c
+++ b/src/jalv_console.c
@@ -237,7 +237,7 @@ jalv_run_custom_ui(Jalv* jalv)
 		jalv_ui_instantiate(jalv, jalv_native_ui_type(), NULL);
 		idle_iface = (const LV2UI_Idle_Interface*)
 			suil_instance_extension_data(jalv->ui_instance, LV2_UI__idleInterface);
-		show_iface = (LV2UI_Show_Interface*)
+		show_iface = (const LV2UI_Show_Interface*)
 			suil_instance_extension_data(jalv->ui_instance, LV2_UI__showInterface);
 	}
 

--- a/src/jalv_console.c
+++ b/src/jalv_console.c
@@ -50,17 +50,19 @@ print_usage(const char* name, bool error)
 }
 
 int
-jalv_ui_resize(Jalv* jalv, int width, int height)
+jalv_ui_resize(ZIX_UNUSED Jalv* jalv,
+               ZIX_UNUSED int   width,
+               ZIX_UNUSED int   height)
 {
-	return 0;
+	return height;
 }
 
 void
-jalv_ui_port_event(Jalv*       jalv,
-                   uint32_t    port_index,
-                   uint32_t    buffer_size,
-                   uint32_t    protocol,
-                   const void* buffer)
+jalv_ui_port_event(ZIX_UNUSED Jalv*       jalv,
+                   ZIX_UNUSED uint32_t    port_index,
+                   ZIX_UNUSED uint32_t    buffer_size,
+                   ZIX_UNUSED uint32_t    protocol,
+                   ZIX_UNUSED const void* buffer)
 {
 }
 
@@ -131,7 +133,7 @@ jalv_init(int* argc, char*** argv, JalvOptions* opts)
 }
 
 const char*
-jalv_native_ui_type(Jalv* jalv)
+jalv_native_ui_type(void)
 {
 	return NULL;
 }
@@ -232,7 +234,7 @@ jalv_run_custom_ui(Jalv* jalv)
 	const LV2UI_Idle_Interface* idle_iface = NULL;
 	const LV2UI_Show_Interface* show_iface = NULL;
 	if (jalv->ui && jalv->opts.show_ui) {
-		jalv_ui_instantiate(jalv, jalv_native_ui_type(jalv), NULL);
+		jalv_ui_instantiate(jalv, jalv_native_ui_type(), NULL);
 		idle_iface = (const LV2UI_Idle_Interface*)
 			suil_instance_extension_data(jalv->ui_instance, LV2_UI__idleInterface);
 		show_iface = (LV2UI_Show_Interface*)

--- a/src/jalv_gtk.c
+++ b/src/jalv_gtk.c
@@ -87,8 +87,7 @@ size_request(GtkWidget* widget, GtkRequisition* req)
 }
 
 static void
-on_window_destroy(GtkWidget* widget,
-                  gpointer   data)
+on_window_destroy(ZIX_UNUSED GtkWidget* widget, ZIX_UNUSED gpointer data)
 {
 	gtk_main_quit();
 }
@@ -140,7 +139,7 @@ jalv_init(int* argc, char*** argv, JalvOptions* opts)
 }
 
 const char*
-jalv_native_ui_type(Jalv* jalv)
+jalv_native_ui_type(void)
 {
 #if GTK_MAJOR_VERSION == 2
 	return "http://lv2plug.in/ns/extensions/ui#GtkUI";
@@ -152,7 +151,7 @@ jalv_native_ui_type(Jalv* jalv)
 }
 
 static void
-on_save_activate(GtkWidget* widget, void* ptr)
+on_save_activate(ZIX_UNUSED GtkWidget* widget, void* ptr)
 {
 	Jalv* jalv = (Jalv*)ptr;
 	GtkWidget* dialog = gtk_file_chooser_dialog_new(
@@ -175,7 +174,7 @@ on_save_activate(GtkWidget* widget, void* ptr)
 }
 
 static void
-on_quit_activate(GtkWidget* widget, gpointer data)
+on_quit_activate(ZIX_UNUSED GtkWidget* widget, gpointer data)
 {
 	GtkWidget* window = (GtkWidget*)data;
 	gtk_widget_destroy(window);
@@ -234,7 +233,7 @@ on_preset_activate(GtkWidget* widget, gpointer data)
 }
 
 static void
-on_preset_destroy(gpointer data, GClosure* closure)
+on_preset_destroy(gpointer data, ZIX_UNUSED GClosure* closure)
 {
 	PresetRecord* record = (PresetRecord*)data;
 	lilv_node_free(record->preset);
@@ -277,7 +276,7 @@ pset_menu_free(PresetMenu* menu)
 }
 
 static gint
-menu_cmp(gconstpointer a, gconstpointer b, gpointer data)
+menu_cmp(gconstpointer a, gconstpointer b, ZIX_UNUSED gpointer data)
 {
 	return strcmp(((PresetMenu*)a)->label, ((PresetMenu*)b)->label);
 }
@@ -532,7 +531,10 @@ set_float_control(const ControlID* control, float value)
 }
 
 static double
-get_atom_double(Jalv* jalv, uint32_t size, LV2_URID type, const void* body)
+get_atom_double(Jalv*               jalv,
+                ZIX_UNUSED uint32_t size,
+                LV2_URID            type,
+                const void*         body)
 {
 	if (type == jalv->forge.Int || type == jalv->forge.Bool) {
 		return *(const int32_t*)body;
@@ -1003,7 +1005,7 @@ add_control_row(GtkWidget*  table,
 }
 
 static int
-control_group_cmp(const void* p1, const void* p2, void* data)
+control_group_cmp(const void* p1, const void* p2, ZIX_UNUSED void* data)
 {
 	const ControlID* control1 = *(const ControlID**)p1;
 	const ControlID* control2 = *(const ControlID**)p2;
@@ -1153,7 +1155,7 @@ build_menu(Jalv* jalv, GtkWidget* window, GtkWidget* vbox)
 }
 
 bool
-jalv_discover_ui(Jalv* jalv)
+jalv_discover_ui(ZIX_UNUSED Jalv* jalv)
 {
 	return TRUE;
 }
@@ -1184,7 +1186,7 @@ jalv_open_ui(Jalv* jalv)
 
 	/* Attempt to instantiate custom UI if necessary */
 	if (jalv->ui && !jalv->opts.generic_ui) {
-		jalv_ui_instantiate(jalv, jalv_native_ui_type(jalv), alignment);
+		jalv_ui_instantiate(jalv, jalv_native_ui_type(), alignment);
 	}
 
 	if (jalv->ui_instance) {
@@ -1230,7 +1232,7 @@ jalv_open_ui(Jalv* jalv)
 }
 
 int
-jalv_close_ui(Jalv* jalv)
+jalv_close_ui(ZIX_UNUSED Jalv* jalv)
 {
 	gtk_main_quit();
 	return 0;

--- a/src/jalv_gtk.c
+++ b/src/jalv_gtk.c
@@ -278,7 +278,7 @@ pset_menu_free(PresetMenu* menu)
 static gint
 menu_cmp(gconstpointer a, gconstpointer b, ZIX_UNUSED gpointer data)
 {
-	return strcmp(((PresetMenu*)a)->label, ((PresetMenu*)b)->label);
+	return strcmp(((const PresetMenu*)a)->label, ((const PresetMenu*)b)->label);
 }
 
 static PresetMenu*
@@ -1007,8 +1007,8 @@ add_control_row(GtkWidget*  table,
 static int
 control_group_cmp(const void* p1, const void* p2, ZIX_UNUSED void* data)
 {
-	const ControlID* control1 = *(const ControlID**)p1;
-	const ControlID* control2 = *(const ControlID**)p2;
+	const ControlID* control1 = *(const ControlID*const*)p1;
+	const ControlID* control2 = *(const ControlID*const*)p2;
 
 	const int cmp = (control1->group && control2->group)
 		? strcmp(lilv_node_as_string(control1->group),

--- a/src/jalv_gtkmm2.cpp
+++ b/src/jalv_gtkmm2.cpp
@@ -30,7 +30,7 @@ jalv_init(int* argc, char*** argv, JalvOptions* opts)
 }
 
 const char*
-jalv_native_ui_type(Jalv* jalv)
+jalv_native_ui_type(void)
 {
 	return "http://lv2plug.in/ns/extensions/ui#GtkUI";
 }
@@ -73,7 +73,7 @@ jalv_open_ui(Jalv* jalv)
 	Gtk::Window* window = new Gtk::Window();
 
 	if (jalv->ui) {
-		jalv_ui_instantiate(jalv, jalv_native_ui_type(jalv), NULL);
+		jalv_ui_instantiate(jalv, jalv_native_ui_type(), NULL);
 	}
 
 	if (jalv->ui_instance) {

--- a/src/jalv_internal.h
+++ b/src/jalv_internal.h
@@ -362,7 +362,7 @@ jalv_set_control(const ControlID* control,
                  const void*      body);
 
 const char*
-jalv_native_ui_type(Jalv* jalv);
+jalv_native_ui_type(void);
 
 bool
 jalv_discover_ui(Jalv* jalv);

--- a/src/jalv_qt.cpp
+++ b/src/jalv_qt.cpp
@@ -334,7 +334,7 @@ jalv_init(int* argc, char*** argv, JalvOptions* opts)
 }
 
 const char*
-jalv_native_ui_type(Jalv* jalv)
+jalv_native_ui_type(void)
 {
 #if QT_VERSION >= 0x050000
 	return "http://lv2plug.in/ns/extensions/ui#Qt5UI";
@@ -687,7 +687,7 @@ jalv_open_ui(Jalv* jalv)
 	jalv_load_presets(jalv, add_preset_to_menu, presets_menu);
 
 	if (jalv->ui && !jalv->opts.generic_ui) {
-		jalv_ui_instantiate(jalv, jalv_native_ui_type(jalv), win);
+		jalv_ui_instantiate(jalv, jalv_native_ui_type(), win);
 	}
 
 	QWidget* widget;

--- a/src/state.c
+++ b/src/state.c
@@ -146,11 +146,11 @@ jalv_unload_presets(Jalv* jalv)
 }
 
 static void
-set_port_value(const char* port_symbol,
-               void*       user_data,
-               const void* value,
-               uint32_t    size,
-               uint32_t    type)
+set_port_value(const char*         port_symbol,
+               void*               user_data,
+               const void*         value,
+               ZIX_UNUSED uint32_t size,
+               uint32_t            type)
 {
 	Jalv*        jalv = (Jalv*)user_data;
 	struct Port* port = jalv_port_by_symbol(jalv, port_symbol);

--- a/src/worker.c
+++ b/src/worker.c
@@ -61,7 +61,7 @@ worker_func(void* data)
 }
 
 void
-jalv_worker_init(Jalv*                       jalv,
+jalv_worker_init(ZIX_UNUSED Jalv*            jalv,
                  JalvWorker*                 worker,
                  const LV2_Worker_Interface* iface,
                  bool                        threaded)

--- a/src/zix/common.h
+++ b/src/zix/common.h
@@ -52,6 +52,12 @@ extern "C" {
 #    include <stdbool.h>
 #endif
 
+#ifdef __GNUC__
+#define ZIX_UNUSED  __attribute__((__unused__))
+#else
+#define ZIX_UNUSED
+#endif
+
 typedef enum {
 	ZIX_STATUS_SUCCESS,
 	ZIX_STATUS_ERROR,


### PR DESCRIPTION
JALV was build with the following command
$ ./waf build --cflags "-Wall -Werror -Wextra -Wformat -Wno-format-
nonliteral -Wformat-security -Wformat-y2k"

to find possible critical issues.
To avoid to recheck the same warnings always by hand I would like to fix also this non critical warnings.