### PR TITLE
Fix a potential crash when closed with worker

### DIFF
--- a/src/jalv.c
+++ b/src/jalv.c
@@ -1179,6 +1179,9 @@ main(int argc, char** argv)
 	}
 	jalv_backend_close(&jalv);
 
+	/* Destroy the worker */
+	jalv_worker_destroy(&jalv.worker);
+
 	/* Deactivate plugin */
 	suil_instance_free(jalv.ui_instance);
 	lilv_instance_deactivate(jalv.instance);

--- a/src/worker.c
+++ b/src/worker.c
@@ -81,10 +81,17 @@ jalv_worker_init(Jalv*                       jalv,
 void
 jalv_worker_finish(JalvWorker* worker)
 {
+	if (worker->threaded) {
+		zix_sem_post(&worker->sem);
+		zix_thread_join(worker->thread, NULL);
+	}
+}
+
+void
+jalv_worker_destroy(JalvWorker* worker)
+{
 	if (worker->requests) {
 		if (worker->threaded) {
-			zix_sem_post(&worker->sem);
-			zix_thread_join(worker->thread, NULL);
 			zix_ring_free(worker->requests);
 		}
 		zix_ring_free(worker->responses);

--- a/src/worker.h
+++ b/src/worker.h
@@ -27,6 +27,9 @@ jalv_worker_init(Jalv*                       jalv,
 void
 jalv_worker_finish(JalvWorker* worker);
 
+void
+jalv_worker_destroy(JalvWorker* worker);
+
 LV2_Worker_Status
 jalv_worker_schedule(LV2_Worker_Schedule_Handle handle,
                      uint32_t                   size,


### PR DESCRIPTION
There is a timeframe when jalv is closed, where the program will crash if the worker is sollicited.
This timeframe goes from the deletion of the worker's buffer, to the deactivation of the jack client.

This error happened on wolf-shaper, a plugin created using DPF framework.
It will attempt to read from a freed ringbuffer.

To prevent this, I think it's adequate to maintain the semaphore and the buffer alive until after jack's deactivation.