### PR TITLE
fixup! Remove support for deprecated event and uri-map extensions

### DIFF
--- a/src/jalv_internal.h
+++ b/src/jalv_internal.h
@@ -213,7 +213,6 @@ typedef struct {
 	LilvNode* atom_Float;
 	LilvNode* atom_Path;
 	LilvNode* atom_Sequence;
-	LilvNode* ev_EventPort;
 	LilvNode* lv2_AudioPort;
 	LilvNode* lv2_CVPort;
 	LilvNode* lv2_ControlPort;


### PR DESCRIPTION
The ev_EventPort is no longer used by anyone and can also be removed.

Signed-off-by: Timo Wischer <twischer@de.adit-jv.com>