### PR TITLE
Provide generic interface for control backend implementations

### DIFF
--- a/src/control_backend.h
+++ b/src/control_backend.h
@@ -1,0 +1,122 @@
+/*
+  Copyright 2019 Timo Wischer <twischer@de.adit-jv.com>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THIS SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#ifndef CONTROL_BACKEND_H
+#define CONTROL_BACKEND_H
+#include "jalv_internal.h"
+
+/**
+ * @brief jalv_control_backend_init initializes the ControlBackend structure if
+ * required. This is called once for each JALV instance.
+ * @param jalv
+ * @return <0 on error
+ *          0 on success
+ */
+int jalv_control_backend_init(Jalv* const jalv);
+
+/**
+ * @brief jalv_control_port_init initializes the ControlPort structure. This is
+ * called for each control port.
+ * @param jalv
+ * @param port
+ * @return <0 on error
+ *          0 on success
+ */
+int jalv_control_port_init(Jalv* const jalv, struct Port* const port);
+
+/**
+ * @brief jalv_control_port_destroy destroys the ControlPort structure. This is
+ * called for each control port.
+ * @param jalv
+ * @param port
+ * @return
+ */
+int jalv_control_port_destroy(Jalv *jalv, struct Port* const port);
+
+/**
+ * @brief jalv_control_backend_destroy destroys the ControlBackend structure if
+ * required. This is called once for each JALV instance.
+ * @param jalv
+ * @return
+ */
+int jalv_control_backend_destroy(Jalv* const jalv);
+
+/**
+ * @brief jalv_control_lock has to be called before accessing returned pointer
+ * of jalv_control_data()
+ * @param jalv
+ * @return <0 on error
+ *          0 on success
+ */
+int jalv_control_lock(Jalv* const jalv);
+
+/**
+ * @brief jalv_control_before_run called with jalv_control_lock() before calling
+ * the next lv2::run()
+ * @param jalv
+ * @return <0 on error
+ *          0 on success
+ */
+int jalv_control_before_run(Jalv* const jalv);
+
+/**
+ * @brief jalv_control_after_run called with jalv_control_lock() after calling
+ * the next lv2::run()
+ * @param jalv
+ * @return <0 on error
+ *          0 on success
+ */
+int jalv_control_after_run(Jalv* const jalv);
+
+/**
+ * @brief jalv_control_unlock unlocks the control memory. Therefore pointer
+ * returned by jalv_control_data() should not be accessed anymore.
+ * @param jalv
+ * @return <0 on error
+ *          0 on success
+ */
+int jalv_control_unlock(Jalv* const jalv);
+
+/**
+ * @brief jalv_control_data has only to be used when jalv_control_lock() was
+ * called before
+ * @param jalv
+ * @param port
+ * @return NULL on error else pointer to memory
+ */
+float* const jalv_control_data(Jalv* const jalv, struct Port* const port);
+
+/**
+ * @brief jalv_control_get can be called from any thread context. No need to
+ * call jalv_control_lock() before
+ * @param jalv
+ * @param port
+ * @return the current value of the port
+ */
+float jalv_control_get(Jalv* const jalv, struct Port* const port);
+
+/**
+ * @brief jalv_control_set can be called from any thread context. No need to
+ * call jalv_control_lock() before
+ * @param jalv
+ * @param port
+ * @param value the new value for the port
+ * @return <0 on error
+ *          0 on success
+ */
+int jalv_control_set(Jalv* const jalv, struct Port* const port, const float value);
+
+#endif // CONTROL_BACKEND_H

--- a/src/control_simple.c
+++ b/src/control_simple.c
@@ -1,0 +1,88 @@
+/*
+  Copyright 2019 Timo Wischer <twischer@de.adit-jv.com>
+
+  Permission to use, copy, modify, and/or distribute this software for any
+  purpose with or without fee is hereby granted, provided that the above
+  copyright notice and this permission notice appear in all copies.
+
+  THIS SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "control_backend.h"
+
+struct ControlPort {
+	float value;
+};
+
+int jalv_control_backend_init(Jalv* const jalv)
+{
+	/* not used */
+	jalv->control_backend = NULL;
+	return 0;
+}
+
+int jalv_control_port_init(Jalv* const jalv, struct Port* const port)
+{
+	port->control = calloc(sizeof(struct ControlPort), 1);
+	if (!port->control)
+		return -1;
+
+	port->control->value = 0.0f;
+
+	return 0;
+}
+
+int jalv_control_port_destroy(Jalv* const jalv, struct Port* const port)
+{
+	free(port->control);
+
+	return 0;
+}
+
+int jalv_control_backend_destroy(Jalv* const jalv)
+{
+	return 0;
+}
+
+int jalv_control_lock(Jalv* const jalv)
+{
+	return 0;
+}
+
+int jalv_control_before_run(Jalv* const jalv)
+{
+	return 0;
+}
+
+int jalv_control_after_run(Jalv* const jalv)
+{
+	return 0;
+}
+
+int jalv_control_unlock(Jalv* const jalv)
+{
+	return 0;
+}
+
+float* const jalv_control_data(Jalv* const jalv, struct Port* const port)
+{
+	return &port->control->value;
+}
+
+float jalv_control_get(Jalv* const jalv, struct Port* const port)
+{
+	return port->control->value;
+}
+
+int jalv_control_set(Jalv* const jalv, struct Port* const port, const float value)
+{
+	port->control->value = value;
+
+	return 0;
+}

--- a/src/jalv_internal.h
+++ b/src/jalv_internal.h
@@ -61,6 +61,8 @@ extern "C" {
 #endif
 
 typedef struct JalvBackend JalvBackend;
+typedef struct ControlBackend ControlBackend;
+typedef struct ControlPort ControlPort;
 
 typedef struct Jalv Jalv;
 
@@ -87,7 +89,7 @@ struct Port {
 	void*           widget;     ///< Control widget, if applicable
 	size_t          buf_size;   ///< Custom buffer size, or 0
 	uint32_t        index;      ///< Port index
-	float           control;    ///< For control ports, otherwise 0.0f
+	ControlPort*    control;    ///< For control ports, otherwise NULL
 };
 
 /* Controls */
@@ -321,6 +323,7 @@ struct Jalv {
 	void*              window;         ///< Window (if applicable)
 	struct Port*       ports;          ///< Port array of size num_ports
 	Controls           controls;       ///< Available plugin controls
+	ControlBackend*    control_backend;///< Control backend
 	uint32_t           block_length;   ///< Audio buffer size (block length)
 	size_t             midi_buf_size;  ///< Size of MIDI port buffers
 	uint32_t           control_in;     ///< Index of control input port

--- a/src/state.c
+++ b/src/state.c
@@ -30,6 +30,7 @@
 
 #include "jalv_config.h"
 #include "jalv_internal.h"
+#include "control_backend.h"
 
 #define NS_JALV "http://drobilla.net/ns/jalv#"
 #define NS_RDF  "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -57,7 +58,10 @@ get_port_value(const char* port_symbol,
 	if (port && port->flow == FLOW_INPUT && port->type == TYPE_CONTROL) {
 		*size = sizeof(float);
 		*type = jalv->forge.Float;
-		return &port->control;
+		// TODO will be called by gtk when lv2 is possibly running and changing the values
+		// Therefore invalid data could be read
+		// Possibly repeat save process until lv2 processing was not executed in between
+		return jalv_control_data(jalv, port);
 	}
 	*size = *type = 0;
 	return NULL;
@@ -156,7 +160,7 @@ set_port_value(const char*         port_symbol,
 
 	if (jalv->play_state != JALV_RUNNING) {
 		// Set value on port struct directly
-		port->control = fvalue;
+		jalv_control_set(jalv, port, fvalue);
 	} else {
 		// Send value to running plugin
 		jalv_ui_write(jalv, port->index, sizeof(fvalue), 0, &fvalue);

--- a/wscript
+++ b/wscript
@@ -160,6 +160,10 @@ def build(bld):
     src/zix/ring.c
     '''
 
+    # When adding additional control backend implementations
+    # use this as the default one
+    source += 'src/control_simple.c '
+
     if bld.env.HAVE_JACK:
         source += 'src/jack.c'
 


### PR DESCRIPTION
This interface allows to implement different backends for the lv2 control ports. The simple backend implements the current behavior.

Another backend implementation could provide a simple telnet server to change and read the control ports.

I will rebase https://github.com/drobilla/jalv/pull/21 on top of this PR soon. So this would be the second control backend implementation. By default the simple backend will be used but at compile time the implementation of https://github.com/drobilla/jalv/pull/21 can be selected.

Please provide your feedback what you think about this additional interface. Are you missing any functions?