### PR TITLE
convert sample_rate to float instead of uint32_t

### DIFF
--- a/src/jalv_internal.h
+++ b/src/jalv_internal.h
@@ -327,7 +327,7 @@ struct Jalv {
 	uint32_t           num_ports;      ///< Size of the two following arrays:
 	uint32_t           plugin_latency; ///< Latency reported by plugin (if any)
 	float              ui_update_hz;   ///< Frequency of UI updates
-	uint32_t           sample_rate;    ///< Sample rate
+	float              sample_rate;    ///< Sample rate
 	uint32_t           event_delta_t;  ///< Frames since last update sent to UI
 	uint32_t           position;       ///< Transport position in frames
 	float              bpm;            ///< Transport tempo in beats per minute


### PR DESCRIPTION
this should be float

3BandEQ complains if it's an int.

I checked by debugging 3BandEQ and if you pass an int it receives a 0.000 sample rate and so it complains. changing this to float made it receive the correct sample rate