### PR TITLE
Fix problems with preset loading.

### DIFF
--- a/src/jalv_console.c
+++ b/src/jalv_console.c
@@ -155,7 +155,7 @@ jalv_print_preset(Jalv*           jalv,
 static void
 jalv_process_command(Jalv* jalv, const char* cmd)
 {
-	char     sym[255];
+	char     sym[512];
 	uint32_t index;
 	float    value;
 	if (!strncmp(cmd, "help", 4)) {
@@ -263,7 +263,7 @@ jalv_open_ui(Jalv* jalv)
 	if (!jalv_run_custom_ui(jalv) && !jalv->opts.non_interactive) {
 		// Primitive command prompt for setting control values
 		while (!zix_sem_try_wait(&jalv->done)) {
-			char line[128];
+			char line[512];
 			printf("> ");
 			if (fgets(line, sizeof(line), stdin)) {
 				jalv_process_command(jalv, line);

--- a/src/jalv_console.c
+++ b/src/jalv_console.c
@@ -155,7 +155,7 @@ jalv_print_preset(Jalv*           jalv,
 static void
 jalv_process_command(Jalv* jalv, const char* cmd)
 {
-	char     sym[64];
+	char     sym[255];
 	uint32_t index;
 	float    value;
 	if (!strncmp(cmd, "help", 4)) {
@@ -174,6 +174,7 @@ jalv_process_command(Jalv* jalv, const char* cmd)
 		jalv_load_presets(jalv, jalv_print_preset, NULL);
 	} else if (sscanf(cmd, "preset %[a-zA-Z0-9_:/-.#]\n", sym) == 1) {
 		LilvNode* preset = lilv_new_uri(jalv->world, sym);
+		lilv_world_load_resource(jalv->world, preset);
 		jalv_apply_preset(jalv, preset);
 		lilv_node_free(preset);
 		jalv_print_controls(jalv, true, false);


### PR DESCRIPTION
This PR addresses 2 problems: 
+ Loading presets with long URIs produce Segmentation Fault.
+ Some presets are not correctly loaded. Adding "lilv_world_load_resource(jalv->world, preset);" solves the problem.