### PR TITLE
jalv: fix segfault on freeing NULL ui_events and plugin_events

### DIFF
--- a/src/jalv.c
+++ b/src/jalv.c
@@ -1273,8 +1273,10 @@ jalv_close(Jalv* const jalv)
 
 	/* Clean up */
 	free(jalv->ports);
-	zix_ring_free(jalv->ui_events);
-	zix_ring_free(jalv->plugin_events);
+	if (jalv->ui_events)
+		zix_ring_free(jalv->ui_events);
+	if (jalv->plugin_events)
+		zix_ring_free(jalv->plugin_events);
 	for (LilvNode** n = (LilvNode**)&jalv->nodes; *n; ++n) {
 		lilv_node_free(*n);
 	}


### PR DESCRIPTION
zix_ring_free() does not check to see if the pointer it is being
passed is NULL before dereferencing its internal ->buf pointer to
the ring data. This causes a (0x0)->buf dereference, resulting in
the segfault.

Both jalv->ui_events and jalv->plugin_events are prone to this issue.

Signed-off-by: Harry van Haaren <harryhaaren@gmail.com>

---

An alternate solution would be to add a check in zix_ring_free() for
NULL, similar to how libc free() handles NULL.