### PR TITLE
store instead of read 'is_primary' value

### DIFF
--- a/src/jalv.c
+++ b/src/jalv.c
@@ -136,9 +136,10 @@ create_port(Jalv* jalv, uint32_t port_index)
   }
 
   // Store index if this is the designated control input port
-  if (jalv->process.control_in == UINT32_MAX && pport->is_primary &&
+  if (jalv->process.control_in == UINT32_MAX &&
       port->flow == FLOW_INPUT && port->type == TYPE_EVENT) {
     jalv->process.control_in = port_index;
+    pport->is_primary = true;
   }
 
   // Update maximum buffer sizes


### PR DESCRIPTION
Store instead of read the value of 'pport->is_primary' because it is never assigned otherwise. This leads to the port that receives the input events never being found.

Tested with the SPARTA plugin suite, which uses JUCE.